### PR TITLE
fix: remove duplicate listener on getMessages

### DIFF
--- a/src/astrachat.ts
+++ b/src/astrachat.ts
@@ -65,7 +65,7 @@ export class AstrachatNode implements Astrachat {
       onNewMessage,
     );
     logger.debug(`[${this.alias}] Chat found, getting messages...`);
-    return chat.getMessages(onNewMessage);
+    return chat.getMessages();
   }
 
   public async sendMessage(

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -48,9 +48,8 @@ export class Chat {
     }
   }
 
-  public getMessages(onNewMessage?: ChatMessageCallback): ChatMessage[] {
+  public getMessages(): ChatMessage[] {
     logger.info(`Getting messages for ${this.chatName}`);
-    if (onNewMessage) this.listenToNewMessages(onNewMessage);
     this.messages.sort((a, b) => a.timestamp - b.timestamp);
     return this.messages;
   }


### PR DESCRIPTION
Removes the duplicate listener setter on `getMessages` that resulted in executing the callback twice on every message.